### PR TITLE
Resolves #15

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -9,4 +9,22 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    if merchant.save
+      merchant.update(merchant_params)
+      flash[:notice] = "The Merchant has been updated!"
+      redirect_to admin_merchant_path(merchant)
+    end
+  end
+
+  private
+  def merchant_params
+    params.require(:merchant).permit(:name)
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: [:admin, @merchant], local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,3 @@
 <h1><%= @merchant.name %></h1>
+<%= link_to "Update Merchant", edit_admin_merchant_path(@merchant) %>
+<p><%= flash[:notice] %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   resources :admin, only: [:index]
   namespace :admin do
-    resources :merchants, only: [:index, :show]
+    resources :merchants, only: [:index, :show, :edit, :update]
     resources :invoices, only: [:index]
   end
 

--- a/spec/features/admin/merchants/edit.html.erb_spec.rb
+++ b/spec/features/admin/merchants/edit.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+RSpec.describe 'admin merchants edit page', type: :feature do
+  let!(:merch_1) { Merchant.create!(name: 'name_1') }
+  before(:each) { visit edit_admin_merchant_path(merch_1) }
+
+  it "has existing info" do
+    expect(page).to have_field("Name", with: "#{merch_1.name}")
+  end
+
+  it "when I update the information and click submit I am taken back to show and see the updated info" do
+    fill_in("Name", with: "name2")
+    click_button("Update Merchant")
+    expect(current_path).to eq(admin_merchant_path(merch_1.id))
+    expect(page).to have_content("name2")
+    expect(:notice).to be_present
+  end
+end

--- a/spec/features/admin/merchants/show.html.erb_spec.rb
+++ b/spec/features/admin/merchants/show.html.erb_spec.rb
@@ -12,4 +12,9 @@ RSpec.describe 'admin merchants index dashboard page', type: :feature do
       end
     end
   end
+      it "links to a merchant edit page" do
+        expect(page).to have_content("Update Merchant")
+        click_link "Update Merchant"
+        expect(current_path).to eq(edit_admin_merchant_path(merch_1))
+      end
 end


### PR DESCRIPTION
-admin merchant show page links to edit page
-edit page come prefilled with merchant name
-edit page redirects back to admin merchant show page
-flash message appears when merchant is updated.